### PR TITLE
Some improvements to the redirect handling

### DIFF
--- a/404-fallback.php
+++ b/404-fallback.php
@@ -17,7 +17,27 @@ require_once plugin_dir_path( __FILE__ ) . '/lib/menus.php';
 require_once plugin_dir_path( __FILE__ ) . '/lib/menu-site.php';
 
 function fb404_redirect_404() {
-	global $wp;
+	/**
+	 * Retrieve the Request URI. We use the server variable rather than `$wp->request` as we wish to retain the query
+	 * string parameters.
+	 */
+	$request = filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL );
+
+	/**
+	 * If the site is on a Multisite and is using a sub-folder, make sure to remove the site path from the URL before
+	 * redirecting. For sites that are mapped to domain, the path will be a single forward slash (/).
+	 */
+	if ( is_multisite() ) {
+		$site = get_site();
+		if ( ! empty( untrailingslashit( $site->path ) ) ) {
+			$request = str_ireplace( $site->path, '', $request );
+		}
+	}
+
+	/**
+	 * We remove the forward slash (/) at the prefix for predictability.
+	 */
+	$request = ltrim( $request, '/' );
 
 	$request = wp_unslash( $_SERVER['REQUEST_URI'] );
 	$url = stripslashes( get_option( 'fb404_setting_fallback_url' ));

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -17,6 +17,13 @@ require_once plugin_dir_path( __FILE__ ) . '/lib/menus.php';
 require_once plugin_dir_path( __FILE__ ) . '/lib/menu-site.php';
 
 function fb404_redirect_404() {
+	/**
+	 * We only want to handle 404 requests.
+	 */
+	if ( ! is_404() ) {
+		return;
+	}
+
 	$request = fb404_get_request();
 
 	$url = fb404_validate_url( get_option( 'fb404_setting_fallback_url', '' ) );
@@ -36,7 +43,7 @@ function fb404_redirect_404() {
 	wp_redirect( $location, $status, $x_redirect_by );
 	die;
 }
-add_action( 'set_404', 'fb404_redirect_404' );
+add_action( 'template_redirect', 'fb404_redirect_404' );
 
 /**
  * Add a site menu called Cluster

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -103,6 +103,10 @@ function fb404_setting_fallback_url_render() {
  * @return string Request URI.
  */
 function fb404_get_request() {
+	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		return '';
+	}
+
 	/**
 	 * Retrieve the Request URI. We use the server variable rather than `$wp->request` as we wish to retain the query
 	 * string parameters.

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -19,18 +19,8 @@ require_once plugin_dir_path( __FILE__ ) . '/lib/menu-site.php';
 function fb404_redirect_404() {
 	$request = fb404_get_request();
 
-	/**
-	 * Get the URL setting and make sure it's a proper value.
-	 */
-	$original_url = strtolower( wp_unslash( get_option( 'fb404_setting_fallback_url', '' ) ) );
-
-	$url = wp_kses_bad_protocol( $original_url, [ 'http', 'https' ] );
-	if ( empty( $url ) || $original_url !== $url ) {
-		return;
-	}
-
-	$parsed_url = parse_url( $url );
-	if ( ! $parsed_url || empty( $parsed_url['host'] ) ) {
+	$url = fb404_validate_url( get_option( 'fb404_setting_fallback_url', '' ) );
+	if ( empty( $url ) ) {
 		return;
 	}
 
@@ -124,4 +114,32 @@ function fb404_get_request() {
 	 * We remove the forward slash (/) at the prefix for predictability.
 	 */
 	return ltrim( $request, '/' );
+}
+
+/**
+ * Validates a given URL.
+ *
+ * @param string $url URL to validate.
+ * @return string URL if valid. Empty string otherwise.
+ */
+function fb404_validate_url( $url = '' ) {
+	if ( empty( $url ) ) {
+		return '';
+	}
+
+	/**
+	 * Get the URL setting and make sure it's a proper value.
+	 */
+	$original_url = strtolower( wp_unslash( $url ) );
+	$url          = wp_kses_bad_protocol( $original_url, [ 'http', 'https' ] );
+	if ( empty( $url ) || $original_url !== $url ) {
+		return '';
+	}
+
+	$parsed_url = parse_url( $url );
+	if ( ! $parsed_url || empty( $parsed_url['host'] ) ) {
+		return '';
+	}
+
+	return $url;
 }

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -79,10 +79,21 @@ function fb404_page_update_handler() {
 }
 
 function fb404_setting_fallback_url_render() {
-	$option_name = 'fb404_setting_fallback_url';
-	$config      = stripslashes( get_option( $option_name ) );
-	printf( '<input name="%1$s" value="%2$s"
-	size="48"/>', $option_name, $config );
+	$config = wp_unslash( get_option( 'fb404_setting_fallback_url', '' ) );
+
+	echo wp_kses(
+		sprintf(
+			'<input name="fb404_setting_fallback_url" value="%1$s" size="48"/>',
+			esc_attr( $config )
+		),
+		[
+			'input' => [
+				'name'  => [],
+				'size'  => [],
+				'value' => [],
+			],
+		]
+	);
 }
 
 /**

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -83,14 +83,16 @@ function fb404_setting_fallback_url_render() {
 
 	echo wp_kses(
 		sprintf(
-			'<input name="fb404_setting_fallback_url" value="%1$s" size="48"/>',
+			'<input type="url" name="fb404_setting_fallback_url" value="%1$s" required size="48"/>',
 			esc_attr( $config )
 		),
 		[
 			'input' => [
-				'name'  => [],
-				'size'  => [],
-				'value' => [],
+				'name'     => [],
+				'required' => [],
+				'size'     => [],
+				'type'     => [],
+				'value'    => [],
 			],
 		]
 	);

--- a/404-fallback.php
+++ b/404-fallback.php
@@ -30,14 +30,13 @@ function fb404_redirect_404() {
 	$location  = trailingslashit( $url);
 	$location .= $request;
 
-	if ( is_404() && ! empty( $location ) ) {
-		$status        = 302;
-		$x_redirect_by = '404 Fallback';
-		wp_redirect( $location, $status, $x_redirect_by );
-		die;
-	}
+	$status        = 302;
+	$x_redirect_by = '404 Fallback';
+
+	wp_redirect( $location, $status, $x_redirect_by );
+	die;
 }
-add_action( 'template_redirect', 'fb404_redirect_404' );
+add_action( 'set_404', 'fb404_redirect_404' );
 
 /**
  * Add a site menu called Cluster


### PR DESCRIPTION
This PR transposes some of the mechanisms from upcoming changes in my own domain mapping plugin that seemed equally relevant here. The changes include:

* ~Switched the handler to `set_404` hook rather than `template_redirect` - it fires earlier in the process and only fires when `WP_Query` determines there is a 404. **Note:** this means the plugin code only supports WordPress 5.5.x or newer.~ Switched it back to `template_redirect` for broader compatibility between older and newer versions of WordPress; https://github.com/svandragt/404-fallback/pull/9/commits/46a67be8ba535c8b6fb81033ff5eb28e369466e1.
* Enhanced validation for the Fallback URL during the redirect phase, to ensure the admin controls cannot be circumvented with say the WP CLI using `wp option update fb404_setting_fallback_url "gibberish"`. This fixes half of the need for https://github.com/svandragt/404-fallback/issues/8.
* Sub-folder multisite support for Request. So in setups which have, https://multisite.test/sub-folder/, it will now ensure `/sub-folder/` doesn't get prepended to the Request on the Fallback URL. Most likely a very rare edge case, as I imagine most sites using this will be mapped in some form.
* Made sure the Fallback URL + Request URI join doesn't accidentally get a double slash `//`.
* Adding some attribute escaping and reworked in the Fallback URL field.
  * Type is now `url` which will now benefit from in-browser (for modern browsers at least ...) validation.
  * Set the `required` attribute to benefit from in-browser validation.
  * Ensured the value attribute has is escaped.
  * Wrapped the `<input>` in `wp_kses()`. Probably overkill but since it was a string and this guarantees the HTML output, it's a bit safer.
  * This partly improves https://github.com/svandragt/404-fallback/issues/8 but the sanitisation will need to be added to [Settings API implementation here](https://github.com/svandragt/404-fallback/blob/ba44e4089558163c3c97735b644a92b07ae8aa47/lib/menus.php#L49-L50). You could reuse the `fb404_validate_url()` function I've added for this. **Note:** I left this out as because there is a few issues around Menu that looked better suited for solving this side.